### PR TITLE
Fix runloop and tests

### DIFF
--- a/addon/mixins/responds-to-enter-keydown.js
+++ b/addon/mixins/responds-to-enter-keydown.js
@@ -6,16 +6,14 @@ var listeners = [];
 // Triggers 'enterKeydown' event and calls 'enterKeydown' on each listener in LIFO order.
 // - halts if a handler returns a truthy value
 Ember.$(window).on('keydown', this, function (e) {
-  if (e.which !== ENTER_CODE) return;
+  if (e.which !== ENTER_CODE) { return; }
   listeners.some(listener => {
     listener.trigger('enterKeydown');
     return listener.enterKeydown();
   });
 });
 
-export default Ember.Mixin.create(
-  Ember.Evented,
-{
+export default Ember.Mixin.create(Ember.Evented, {
 
   // @return {boolean} stopPropagation
   enterKeydown: Ember.$.noop,

--- a/addon/mixins/responds-to-esc-keydown.js
+++ b/addon/mixins/responds-to-esc-keydown.js
@@ -7,17 +7,15 @@ var listeners = [];
 // - unless target element is a SELECT or INPUT
 // - halts if a handler returns a truthy value
 Ember.$(window).on('keydown', this, function (e) {
-  if (e.which !== ESC_CODE) return;
-  if (['SELECT', 'INPUT'].indexOf(e.target.tagName) > -1) return;
+  if (e.which !== ESC_CODE) { return; }
+  if (['SELECT', 'INPUT'].indexOf(e.target.tagName) > -1) { return; }
   listeners.some(listener => {
     listener.trigger('escKeydown');
     return listener.escKeydown();
   });
 });
 
-export default Ember.Mixin.create(
-  Ember.Evented,
-{
+export default Ember.Mixin.create(Ember.Evented, {
 
   // @return {boolean} stopPropagation
   escKeydown: Ember.$.noop,

--- a/addon/mixins/responds-to-resize.js
+++ b/addon/mixins/responds-to-resize.js
@@ -9,7 +9,7 @@ export default Ember.Mixin.create(Ember.Evented, {
 
   didInsertElement: function () {
     this._super();
-    this.resizeHandler = this.debouncedResize.bind(this);
+    this.resizeHandler = () => this.debouncedResize();
     Ember.$(window).on(RESIZE_EVENTS, this.resizeHandler);
   },
 
@@ -21,8 +21,10 @@ export default Ember.Mixin.create(Ember.Evented, {
   debouncedResize: function () {
     window.requestAnimationFrame(() => {
       if (this.get('isDestroyed')) { return; }
-      this.trigger('resize');
-      this.resize();
+      Ember.run(() => {
+        this.trigger('resize');
+        this.resize();
+      });
     });
   },
 

--- a/addon/mixins/responds-to-resize.js
+++ b/addon/mixins/responds-to-resize.js
@@ -3,33 +3,31 @@ import Ember from 'ember';
 var RESIZE_EVENTS = 'resize orientationchange';
 
 // Debounces browser event, triggers 'resize' event and calls 'resize' handler.
-export default Ember.Mixin.create(
-  Ember.Evented,
-{
+export default Ember.Mixin.create(Ember.Evented, {
 
   resize: Ember.$.noop,
 
   didInsertElement: function () {
     this._super();
     this.resizeHandler = this.debouncedResize.bind(this);
-    $(window).on(RESIZE_EVENTS, this.resizeHandler);
+    Ember.$(window).on(RESIZE_EVENTS, this.resizeHandler);
   },
 
   willDestroyElement: function () {
     this._super();
-    $(window).off(RESIZE_EVENTS, this.resizeHandler);
+    Ember.$(window).off(RESIZE_EVENTS, this.resizeHandler);
   },
 
   debouncedResize: function () {
     window.requestAnimationFrame(() => {
-      if (this.get('isDestroyed')) return;
+      if (this.get('isDestroyed')) { return; }
       this.trigger('resize');
       this.resize();
     });
   },
 
-  windowWidth: function () {
+  windowWidth: Ember.computed(function () {
     return window.innerWidth;
-  }.property()
+  })
 
 });

--- a/addon/mixins/responds-to-scroll.js
+++ b/addon/mixins/responds-to-scroll.js
@@ -7,7 +7,7 @@ export default Ember.Mixin.create(Ember.Evented, {
 
   didInsertElement: function () {
     this._super();
-    this.scrollHandler = this.debouncedScroll.bind(this);
+    this.scrollHandler = () => this.debouncedScroll();
     Ember.$(window).on('scroll', this.scrollHandler);
   },
 
@@ -19,8 +19,10 @@ export default Ember.Mixin.create(Ember.Evented, {
   debouncedScroll: function () {
     window.requestAnimationFrame(() => {
       if (this.get('isDestroyed')) { return; }
-      this.trigger('scroll');
-      this.scroll();
+      Ember.run(() => {
+        this.trigger('scroll');
+        this.scroll();
+      });
     });
   }
 

--- a/addon/mixins/responds-to-scroll.js
+++ b/addon/mixins/responds-to-scroll.js
@@ -1,26 +1,24 @@
 import Ember from 'ember';
 
 // Debounces browser event, triggers 'scroll' event and calls 'scroll' handler.
-export default Ember.Mixin.create(
-  Ember.Evented,
-{
+export default Ember.Mixin.create(Ember.Evented, {
 
   scroll: Ember.$.noop,
 
   didInsertElement: function () {
     this._super();
     this.scrollHandler = this.debouncedScroll.bind(this);
-    $(window).on('scroll', this.scrollHandler);
+    Ember.$(window).on('scroll', this.scrollHandler);
   },
 
   willDestroyElement: function () {
     this._super();
-    $(window).off('scroll', this.scrollHandler);
+    Ember.$(window).off('scroll', this.scrollHandler);
   },
 
   debouncedScroll: function () {
     window.requestAnimationFrame(() => {
-      if (this.get('isDestroyed')) return;
+      if (this.get('isDestroyed')) { return; }
       this.trigger('scroll');
       this.scroll();
     });

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "ember-cli-content-security-policy": "0.4.0",
     "ember-cli-dependency-checker": "^1.0.0",
     "ember-cli-htmlbars": "0.7.6",
+    "ember-cli-htmlbars-inline-precompile": "0.3.1",
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-inject-live-reload": "^1.3.0",
     "ember-cli-qunit": "0.3.13",

--- a/tests/dummy/app/components/respond-to-resize.js
+++ b/tests/dummy/app/components/respond-to-resize.js
@@ -1,0 +1,8 @@
+import Ember from 'ember';
+import RespondsToResize from 'ember-responds-to/mixins/responds-to-resize';
+
+export default Ember.Component.extend(RespondsToResize, {
+  resize() {
+    this.set('didReceiveResize', true);
+  }
+});

--- a/tests/dummy/app/components/respond-to-scroll.js
+++ b/tests/dummy/app/components/respond-to-scroll.js
@@ -1,0 +1,8 @@
+import Ember from 'ember';
+import RespondsToScroll from 'ember-responds-to/mixins/responds-to-scroll';
+
+export default Ember.Component.extend(RespondsToScroll, {
+  scroll() {
+    this.set('didReceiveScroll', true);
+  }
+});

--- a/tests/dummy/app/templates/components/respond-to-resize.hbs
+++ b/tests/dummy/app/templates/components/respond-to-resize.hbs
@@ -1,0 +1,3 @@
+{{#if didReceiveResize}}
+  <div id='did-receive-resize'>resized</div>
+{{/if}}

--- a/tests/dummy/app/templates/components/respond-to-scroll.hbs
+++ b/tests/dummy/app/templates/components/respond-to-scroll.hbs
@@ -1,0 +1,3 @@
+{{#if didReceiveScroll}}
+  <div id='did-receive-scroll'>scrolled</div>
+{{/if}}

--- a/tests/integration/components/respond-to-resize-test.js
+++ b/tests/integration/components/respond-to-resize-test.js
@@ -1,0 +1,20 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import Ember from 'ember';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('respond-to-resize', {
+  integration: true
+});
+
+test('reacts when resize event is triggered on window', function(assert) {
+  assert.expect(1);
+  const done = assert.async();
+
+  this.render(hbs`{{respond-to-resize}}`);
+  Ember.$(window).trigger('resize');
+
+  setTimeout(() => {
+    assert.ok(this.$('#did-receive-resize').length, 'updated template');
+    done();
+  }, 20);
+});

--- a/tests/integration/components/respond-to-scroll-test.js
+++ b/tests/integration/components/respond-to-scroll-test.js
@@ -1,0 +1,20 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import Ember from 'ember';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('respond-to-scroll', {
+  integration: true
+});
+
+test('reacts when scroll event is triggered on window', function(assert) {
+  assert.expect(1);
+  const done = assert.async();
+
+  this.render(hbs`{{respond-to-scroll}}`);
+  Ember.$(window).trigger('scroll');
+
+  setTimeout(() => {
+    assert.ok(this.$('#did-receive-scroll').length, 'updated template');
+    done();
+  }, 20);
+});

--- a/tests/unit/mixins/responds-to-enter-keydown-test.js
+++ b/tests/unit/mixins/responds-to-enter-keydown-test.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import RespondsToEnterKeydownMixin from '../../../mixins/responds-to-enter-keydown';
+import RespondsToEnterKeydownMixin from 'ember-responds-to/mixins/responds-to-enter-keydown';
 import { module, test } from 'qunit';
 
 module('Unit | Mixin | responds to enter keydown');

--- a/tests/unit/mixins/responds-to-esc-keydown-test.js
+++ b/tests/unit/mixins/responds-to-esc-keydown-test.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import RespondsToEscKeydownMixin from '../../../mixins/responds-to-esc-keydown';
+import RespondsToEscKeydownMixin from 'ember-responds-to/mixins/responds-to-esc-keydown';
 import { module, test } from 'qunit';
 
 module('Unit | Mixin | responds to esc keydown');

--- a/tests/unit/mixins/responds-to-resize-test.js
+++ b/tests/unit/mixins/responds-to-resize-test.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import RespondsToResizeMixin from '../../../mixins/responds-to-resize';
+import RespondsToResizeMixin from 'ember-responds-to/mixins/responds-to-resize';
 import { module, test } from 'qunit';
 
 module('Unit | Mixin | responds to resize');

--- a/tests/unit/mixins/responds-to-scroll-test.js
+++ b/tests/unit/mixins/responds-to-scroll-test.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import RespondsToScrollMixin from '../../../mixins/responds-to-scroll';
+import RespondsToScrollMixin from 'ember-responds-to/mixins/responds-to-scroll';
 import { module, test } from 'qunit';
 
 module('Unit | Mixin | responds to scroll');


### PR DESCRIPTION
I was playing around with this today and noticed that the event-responding code was ignoring ember's runloop, causing some issues in tests.

There are a couple commits here:
- 87590e6 fixes the tests — mostly just fixing jshint and removing usage of a `.property` function prototype extension
- 04eaa4a introduces a few failing tests — these fail because they cause property changes outside of ember's runloop
- 7e78861 fixes the failing tests by using ember's runloop to handle property changes

There are still some runloop-related issues with `RespondsToEnterKeydown` and `RespondsToEscKeydown` that I will issue a separate PR for if I have a chance.
