### PR TITLE
Fix the debouncing for the 'scroll' and 'resize' mixins

### DIFF
--- a/addon/mixins/debounced-response.js
+++ b/addon/mixins/debounced-response.js
@@ -1,0 +1,18 @@
+import Ember from 'ember';
+
+export default Ember.Mixin.create({
+  debounce: function (handler) {
+    return () => {
+      if (!this.isScheduled) {
+        this.isScheduled = true;
+
+        window.requestAnimationFrame(() => {
+          this.isScheduled = false;
+
+          if (this.get('isDestroyed')) return;
+          Ember.run(this, handler);
+        });
+      }
+    };
+  }
+});

--- a/addon/mixins/responds-to-resize.js
+++ b/addon/mixins/responds-to-resize.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import DebouncedResponse from './debounced-response';
 
 var RESIZE_EVENTS = 'resize orientationchange';
 function noop() { }
@@ -6,29 +7,26 @@ function noop() { }
 // Debounces browser event, triggers 'resize' event and calls 'resize' handler.
 export default Ember.Mixin.create(
   Ember.Evented,
+  DebouncedResponse,
 {
 
   resize: noop,
 
   didInsertElement: function () {
-    this._super();
-    this.resizeHandler = () => this.debouncedResize();
+    this._super(...arguments);
+
+    this.resizeHandler = this.debounce(() => {
+      this.trigger('resize');
+      this.resize();
+    });
+
     Ember.$(window).on(RESIZE_EVENTS, this.resizeHandler);
   },
 
   willDestroyElement: function () {
-    this._super();
-    Ember.$(window).off(RESIZE_EVENTS, this.resizeHandler);
-  },
+    this._super(...arguments);
 
-  debouncedResize: function () {
-    window.requestAnimationFrame(() => {
-      if (this.get('isDestroyed')) return;
-      Ember.run(() => {
-        this.trigger('resize');
-        this.resize();
-      });
-    });
-  },
+    Ember.$(window).off(RESIZE_EVENTS, this.resizeHandler);
+  }
 
 });

--- a/addon/mixins/responds-to-scroll.js
+++ b/addon/mixins/responds-to-scroll.js
@@ -1,32 +1,30 @@
 import Ember from 'ember';
+import DebouncedResponse from './debounced-response';
+
 function noop() { }
 
 // Debounces browser event, triggers 'scroll' event and calls 'scroll' handler.
 export default Ember.Mixin.create(
   Ember.Evented,
+  DebouncedResponse,
 {
 
   scroll: noop,
 
   didInsertElement: function () {
-    this._super();
-    this.scrollHandler = () => this.debouncedScroll();
+    this._super(...arguments);
+
+    this.scrollHandler = this.debounce(() => {
+      this.trigger('scroll');
+      this.scroll();
+    });
+
     Ember.$(window).on('scroll', this.scrollHandler);
   },
 
   willDestroyElement: function () {
-    this._super();
+    this._super(...arguments);
+
     Ember.$(window).off('scroll', this.scrollHandler);
-  },
-
-  debouncedScroll: function () {
-    window.requestAnimationFrame(() => {
-      if (this.get('isDestroyed')) return;
-      Ember.run(() => {
-        this.trigger('scroll');
-        this.scroll();
-      });
-    });
   }
-
 });

--- a/tests/dummy/app/components/respond-to-resize.js
+++ b/tests/dummy/app/components/respond-to-resize.js
@@ -11,8 +11,8 @@ export default Ember.Component.extend(
     this.set('resizeCount', 0);
   },
 
-  resize() {
+  onResize: Ember.on('resize', function() {
     this.incrementProperty('resizeCount');
-  }
+  })
 
 });

--- a/tests/dummy/app/components/respond-to-resize.js
+++ b/tests/dummy/app/components/respond-to-resize.js
@@ -5,8 +5,14 @@ export default Ember.Component.extend(
   RespondsToResize,
 {
 
+  init() {
+    this._super(...arguments);
+
+    this.set('resizeCount', 0);
+  },
+
   resize() {
-    this.set('didReceiveResize', true);
+    this.incrementProperty('resizeCount');
   }
 
 });

--- a/tests/dummy/app/components/respond-to-scroll.js
+++ b/tests/dummy/app/components/respond-to-scroll.js
@@ -11,8 +11,8 @@ export default Ember.Component.extend(
     this.set('scrollCount', 0);
   },
 
-  scroll() {
+  onScroll: Ember.on('scroll', function() {
     this.incrementProperty('scrollCount');
-  }
+  })
 
 });

--- a/tests/dummy/app/components/respond-to-scroll.js
+++ b/tests/dummy/app/components/respond-to-scroll.js
@@ -5,8 +5,14 @@ export default Ember.Component.extend(
   RespondsToScroll,
 {
 
+  init() {
+    this._super(...arguments);
+
+    this.set('scrollCount', 0);
+  },
+
   scroll() {
-    this.set('didReceiveScroll', true);
+    this.incrementProperty('scrollCount');
   }
 
 });

--- a/tests/dummy/app/templates/components/respond-to-resize.hbs
+++ b/tests/dummy/app/templates/components/respond-to-resize.hbs
@@ -1,3 +1,1 @@
-{{#if didReceiveResize }}
-  <div id="did-receive-resize">resized</div>
-{{/if}}
+<span id="resize-count">{{resizeCount}}</span>

--- a/tests/dummy/app/templates/components/respond-to-scroll.hbs
+++ b/tests/dummy/app/templates/components/respond-to-scroll.hbs
@@ -1,3 +1,1 @@
-{{#if didReceiveScroll }}
-  <div id="did-receive-scroll">scrolled</div>
-{{/if}}
+<span id="scroll-count">{{scrollCount}}</span>

--- a/tests/integration/components/respond-to-resize-test.js
+++ b/tests/integration/components/respond-to-resize-test.js
@@ -15,7 +15,7 @@ test('it should react when resize event is triggered on window', function (asser
   this.render(hbs`{{ respond-to-resize }}`);
   Ember.$(window).trigger('resize');
   setTimeout(() => {
-    assert.ok(this.$('#did-receive-resize').length, 'updated template');
+    assert.equal(this.$('#resize-count').text(), 2, 'triggered a resize');
     done();
   }, 20);
 });
@@ -26,7 +26,22 @@ test('it should react when orientationchange event is triggered on window', func
   this.render(hbs`{{ respond-to-resize }}`);
   Ember.$(window).trigger('orientationchange');
   setTimeout(() => {
-    assert.ok(this.$('#did-receive-resize').length, 'updated template');
+    assert.equal(this.$('#resize-count').text(), 2, 'triggered a resize');
+    done();
+  }, 20);
+});
+
+test('it debounces the events inside an animation frame', function (assert) {
+  assert.expect(1);
+  const done = assert.async();
+  this.render(hbs`{{ respond-to-resize }}`);
+
+  for (let i = 0; i < 10; i++) {
+    Ember.$(window).trigger('resize');
+  }
+
+  setTimeout(() => {
+    assert.equal(this.$('#resize-count').text(), 2);
     done();
   }, 20);
 });

--- a/tests/integration/components/respond-to-resize-test.js
+++ b/tests/integration/components/respond-to-resize-test.js
@@ -15,7 +15,7 @@ test('it should react when resize event is triggered on window', function (asser
   this.render(hbs`{{ respond-to-resize }}`);
   Ember.$(window).trigger('resize');
   setTimeout(() => {
-    assert.equal(this.$('#resize-count').text(), 2, 'triggered a resize');
+    assert.equal(this.$('#resize-count').text(), 1, 'triggered a resize');
     done();
   }, 20);
 });
@@ -26,7 +26,7 @@ test('it should react when orientationchange event is triggered on window', func
   this.render(hbs`{{ respond-to-resize }}`);
   Ember.$(window).trigger('orientationchange');
   setTimeout(() => {
-    assert.equal(this.$('#resize-count').text(), 2, 'triggered a resize');
+    assert.equal(this.$('#resize-count').text(), 1, 'triggered a resize');
     done();
   }, 20);
 });
@@ -41,7 +41,7 @@ test('it debounces the events inside an animation frame', function (assert) {
   }
 
   setTimeout(() => {
-    assert.equal(this.$('#resize-count').text(), 2);
+    assert.equal(this.$('#resize-count').text(), 1);
     done();
   }, 20);
 });

--- a/tests/integration/components/respond-to-scroll-test.js
+++ b/tests/integration/components/respond-to-scroll-test.js
@@ -15,7 +15,7 @@ test('reacts when scroll event is triggered on window', function (assert) {
   this.render(hbs`{{ respond-to-scroll }}`);
   Ember.$(window).trigger('scroll');
   setTimeout(() => {
-    assert.equal(this.$('#scroll-count').text(), 2, 'triggered a scroll');
+    assert.equal(this.$('#scroll-count').text(), 1, 'triggered a scroll');
     done();
   }, 20);
 });
@@ -30,7 +30,7 @@ test('it debounces the events inside an animation frame', function (assert) {
   }
 
   setTimeout(() => {
-    assert.equal(this.$('#scroll-count').text(), 2);
+    assert.equal(this.$('#scroll-count').text(), 1);
     done();
   }, 20);
 });

--- a/tests/integration/components/respond-to-scroll-test.js
+++ b/tests/integration/components/respond-to-scroll-test.js
@@ -15,7 +15,22 @@ test('reacts when scroll event is triggered on window', function (assert) {
   this.render(hbs`{{ respond-to-scroll }}`);
   Ember.$(window).trigger('scroll');
   setTimeout(() => {
-    assert.ok(this.$('#did-receive-scroll').length, 'updated template');
+    assert.equal(this.$('#scroll-count').text(), 2, 'triggered a scroll');
+    done();
+  }, 20);
+});
+
+test('it debounces the events inside an animation frame', function (assert) {
+  assert.expect(1);
+  const done = assert.async();
+  this.render(hbs`{{ respond-to-scroll }}`);
+
+  for (let i = 0; i < 10; i++) {
+    Ember.$(window).trigger('scroll');
+  }
+
+  setTimeout(() => {
+    assert.equal(this.$('#scroll-count').text(), 2);
     done();
   }, 20);
 });


### PR DESCRIPTION
The debouncing with `requestAnimationFrame` is incorrectly implemented: it merely batched the handlers rather than throttling the request. You can try by running

````
for (var i=0 ; i<10 ; i++) {
  $(window).trigger('resize');
}
````

You will see that it still will still execute all 10 callbacks. It will just batch them to be executed in the next animation frame.

This PR corrects this bug (I added test cases) so that at most only one event is triggered per frame.