### PR TITLE
Pass the event arguments to the handlers

### DIFF
--- a/addon/mixins/debounced-response.js
+++ b/addon/mixins/debounced-response.js
@@ -2,15 +2,18 @@ import Ember from 'ember';
 
 export default Ember.Mixin.create({
   debounce: function (handler) {
-    return () => {
-      if (!this.isScheduled) {
-        this.isScheduled = true;
+    const self = this;
+
+    return function() {
+      if (!self.isScheduled) {
+        self.isScheduled = true;
 
         window.requestAnimationFrame(() => {
-          this.isScheduled = false;
+          self.isScheduled = false;
 
-          if (this.get('isDestroyed')) return;
-          Ember.run(this, handler);
+          if (self.get('isDestroyed')) return;
+
+          Ember.run(this, handler, ...arguments);
         });
       }
     };

--- a/addon/mixins/debounced-response.js
+++ b/addon/mixins/debounced-response.js
@@ -2,18 +2,16 @@ import Ember from 'ember';
 
 export default Ember.Mixin.create({
   debounce(handler) {
-    const self = this;
-
-    return function() {
-      if (!self.isScheduled) {
-        self.isScheduled = true;
+    return (...args) => {
+      if (!this.isScheduled) {
+        this.isScheduled = true;
 
         window.requestAnimationFrame(() => {
-          self.isScheduled = false;
+          this.isScheduled = false;
 
-          if (self.get('isDestroyed')) return;
+          if (this.get('isDestroyed')) return;
 
-          Ember.run(this, handler, ...arguments);
+          Ember.run(this, handler, ...args);
         });
       }
     };

--- a/addon/mixins/debounced-response.js
+++ b/addon/mixins/debounced-response.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 
 export default Ember.Mixin.create({
-  debounce: function (handler) {
+  debounce(handler) {
     const self = this;
 
     return function() {

--- a/addon/mixins/responds-to-resize.js
+++ b/addon/mixins/responds-to-resize.js
@@ -15,9 +15,10 @@ export default Ember.Mixin.create(
   didInsertElement: function () {
     this._super(...arguments);
 
-    this.resizeHandler = this.debounce(() => {
-      this.trigger('resize');
-      this.resize();
+    const self = this;
+    this.resizeHandler = this.debounce(function() {
+      self.trigger('resize', ...arguments);
+      self.resize(...arguments);
     });
 
     Ember.$(window).on(RESIZE_EVENTS, this.resizeHandler);

--- a/addon/mixins/responds-to-resize.js
+++ b/addon/mixins/responds-to-resize.js
@@ -15,10 +15,9 @@ export default Ember.Mixin.create(
   didInsertElement: function () {
     this._super(...arguments);
 
-    const self = this;
-    this.resizeHandler = this.debounce(function() {
-      self.trigger('resize', ...arguments);
-      self.resize(...arguments);
+    this.resizeHandler = this.debounce((...args) => {
+      this.trigger('resize', ...args);
+      this.resize(...args);
     });
 
     Ember.$(window).on(RESIZE_EVENTS, this.resizeHandler);

--- a/addon/mixins/responds-to-scroll.js
+++ b/addon/mixins/responds-to-scroll.js
@@ -14,9 +14,9 @@ export default Ember.Mixin.create(
   didInsertElement: function () {
     this._super(...arguments);
 
-    this.scrollHandler = this.debounce(() => {
-      this.trigger('scroll');
-      this.scroll();
+    this.scrollHandler = this.debounce((...args) => {
+      this.trigger('scroll', ...args);
+      this.scroll(...args);
     });
 
     Ember.$(window).on('scroll', this.scrollHandler);

--- a/tests/dummy/app/components/respond-to-resize.js
+++ b/tests/dummy/app/components/respond-to-resize.js
@@ -11,8 +11,9 @@ export default Ember.Component.extend(
     this.set('resizeCount', 0);
   },
 
-  onResize: Ember.on('resize', function() {
+  onResize: Ember.on('resize', function(evt) {
     this.incrementProperty('resizeCount');
+    this.set('argIsEvent', evt.constructor == jQuery.Event);
   })
 
 });

--- a/tests/dummy/app/components/respond-to-scroll.js
+++ b/tests/dummy/app/components/respond-to-scroll.js
@@ -11,8 +11,9 @@ export default Ember.Component.extend(
     this.set('scrollCount', 0);
   },
 
-  onScroll: Ember.on('scroll', function() {
+  onScroll: Ember.on('scroll', function(evt) {
     this.incrementProperty('scrollCount');
+    this.set('argIsEvent', evt.constructor == jQuery.Event);
   })
 
 });

--- a/tests/dummy/app/templates/components/respond-to-resize.hbs
+++ b/tests/dummy/app/templates/components/respond-to-resize.hbs
@@ -1,1 +1,2 @@
 <span id="resize-count">{{resizeCount}}</span>
+<span id="arg-is-event">{{argIsEvent}}</span>

--- a/tests/dummy/app/templates/components/respond-to-scroll.hbs
+++ b/tests/dummy/app/templates/components/respond-to-scroll.hbs
@@ -1,1 +1,2 @@
 <span id="scroll-count">{{scrollCount}}</span>
+<span id="arg-is-event">{{argIsEvent}}</span>

--- a/tests/integration/components/respond-to-resize-test.js
+++ b/tests/integration/components/respond-to-resize-test.js
@@ -45,3 +45,16 @@ test('it debounces the events inside an animation frame', function (assert) {
     done();
   }, 20);
 });
+
+test('it passes on the jQuery Event object', function (assert) {
+  assert.expect(1);
+  const done = assert.async();
+  this.render(hbs`{{ respond-to-resize }}`);
+
+  Ember.$(window).trigger('resize');
+
+  setTimeout(() => {
+    assert.equal(this.$('#arg-is-event').text(), 'true');
+    done();
+  }, 20);
+});

--- a/tests/integration/components/respond-to-scroll-test.js
+++ b/tests/integration/components/respond-to-scroll-test.js
@@ -34,3 +34,16 @@ test('it debounces the events inside an animation frame', function (assert) {
     done();
   }, 20);
 });
+
+test('it passes on the jQuery Event object', function (assert) {
+  assert.expect(1);
+  const done = assert.async();
+  this.render(hbs`{{ respond-to-scroll }}`);
+
+  Ember.$(window).trigger('scroll');
+
+  setTimeout(() => {
+    assert.equal(this.$('#arg-is-event').text(), 'true');
+    done();
+  }, 20);
+});


### PR DESCRIPTION
This passes the jQuery event callback arguments on to the handler. So it allows to write something like:

````
onResize: Ember.on('resize', function(event) {
  // `event` is the jQuery Event object
})
````